### PR TITLE
Fix accidental assigment during if 

### DIFF
--- a/src/modules/archipelago.ts
+++ b/src/modules/archipelago.ts
@@ -91,7 +91,7 @@ class RCTRArchipelago extends ModuleBase {
         var self = this;
         for(let i = 0; i < item.length; i++){
             var category = "item"; //Any item with the 0b100 flag is always a trap
-            if(item[i].flags = 0b100)
+            if(item[i].flags == 0b100)
             category = "trap";
             if(RideType[item[i].item])//Any item that fits a ride type is a ride
             category = "ride";


### PR DESCRIPTION
Code was assigning flags to be equal to `0b100` instead of checking whether it was that value. Fixed.

As a further improvement, this kind of problem could be caught by adding a linter (like ESLint) to the project. It's a simple add that will temporarily "add" new errors as it sees things you've overlooked. Let me know if you're interested and I can show you that.