### PR TITLE
Update archipelago_enums.ts

### DIFF
--- a/src/archipelago_enums.ts
+++ b/src/archipelago_enums.ts
@@ -20,7 +20,7 @@ enum ScenarioName {
     "dinky park",
     "aqua park",
     "millennium mines",
-    "karts and coasters",
+    "karts & coasters",
     "mel’s world",
     "mothball mountain",
     "pacific pyramids",


### PR DESCRIPTION
Fixes "karts and coasters" to "karts & coasters" so it's playable as a scenario.