### PR TITLE
"karts and coasters" scenario bug fix

### DIFF
--- a/src/archipelago_enums.ts
+++ b/src/archipelago_enums.ts
@@ -20,7 +20,7 @@ enum ScenarioName {
     "dinky park",
     "aqua park",
     "millennium mines",
-    "karts and coasters",
+    "karts & coasters",
     "mel’s world",
     "mothball mountain",
     "pacific pyramids",


### PR DESCRIPTION
Fix playability of the "karts and coasters" scenario by changing the name to "karts & coasters" because OpenRCT2 is expecting the ampersand.